### PR TITLE
feat: add titleClassName prop to FAQs

### DIFF
--- a/lib/components/faq/BusinessFAQ.tsx
+++ b/lib/components/faq/BusinessFAQ.tsx
@@ -35,7 +35,12 @@ const DATA: Record<string, Record<BusinessTopic, FaqJson>> = {
   },
 } as const;
 
-export function BusinessFAQ({ language, className, topic }: BusinessFAQProps) {
+export function BusinessFAQ({
+  language,
+  className,
+  titleClassName,
+  topic,
+}: BusinessFAQProps) {
   const [openItem, setOpenItem] = useState<string | null>(null);
   const { question, answer } = DATA[language][topic];
 
@@ -49,7 +54,12 @@ export function BusinessFAQ({ language, className, topic }: BusinessFAQProps) {
       role="region"
       aria-label={`${topic} FAQ`}
     >
-      <h1 className="text-lg font-bold border-solid border-b w-full py-4">
+      <h1
+        className={cn(
+          "text-lg font-bold border-solid border-b w-full py-4",
+          titleClassName
+        )}
+      >
         {DATA[language][topic].title}
       </h1>
       <Accordion

--- a/lib/components/faq/ShopperFAQ.tsx
+++ b/lib/components/faq/ShopperFAQ.tsx
@@ -30,7 +30,12 @@ const DATA: Record<string, Record<ShopperTopic, FaqJson>> = {
   },
 } as const;
 
-export function ShopperFAQ({ language, className, topic }: ShopperFAQProps) {
+export function ShopperFAQ({
+  language,
+  className,
+  titleClassName,
+  topic,
+}: ShopperFAQProps) {
   const [openItem, setOpenItem] = useState<string | null>(null);
   const { question, answer } = DATA[language][topic];
 
@@ -44,7 +49,12 @@ export function ShopperFAQ({ language, className, topic }: ShopperFAQProps) {
       role="region"
       aria-label={`${topic} FAQ`}
     >
-      <h1 className="text-lg font-bold border-solid border-b w-full py-4">
+      <h1
+        className={cn(
+          "text-lg font-bold border-solid border-b w-full py-4",
+          titleClassName
+        )}
+      >
         {DATA[language][topic].title}
       </h1>
       <Accordion

--- a/lib/components/faq/types.ts
+++ b/lib/components/faq/types.ts
@@ -5,9 +5,11 @@ interface FAQProps {
 
 export interface ShopperFAQProps extends FAQProps {
   topic: ShopperTopic;
+  titleClassName?: string;
 }
 export interface BusinessFAQProps extends FAQProps {
   topic: BusinessTopic;
+  titleClassName?: string;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flizpay-de/ui",
   "private": false,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "sideEffects": [
     "**/*.css"
   ],


### PR DESCRIPTION
- Add titleClassName that can pass a className for each title on each FAQ section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the FAQ title's CSS classes in both Business and Shopper FAQ components through a new optional property.
- **Chores**
  - Updated the package version to 0.0.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->